### PR TITLE
FACES-3253 UploadedFilePart.getBytes() method does not write the exact ranges of bytes read into the byte[] buffer

### DIFF
--- a/jsf-showcase-webapp/src/main/java/com/liferay/faces/showcase/dto/UploadedFilePart.java
+++ b/jsf-showcase-webapp/src/main/java/com/liferay/faces/showcase/dto/UploadedFilePart.java
@@ -93,7 +93,7 @@ public class UploadedFilePart implements UploadedFile, FacesWrapper<Part> {
 		int bytesRead = inputStream.read(byteBuffer);
 
 		while (bytesRead != -1) {
-			byteArrayOutputStream.write(byteBuffer);
+			byteArrayOutputStream.write(byteBuffer, 0, bytesRead);
 			bytesRead = inputStream.read(byteBuffer);
 		}
 


### PR DESCRIPTION
It always writes the full buffer in the output stream, regardless the number of bytes read. It produces a corrupt file. I know it is a showcase but it can be used by many people as base code.