### PR TITLE
Improve/fix build setup (missing repositories, a missing property, resource filtering)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<surefire.version>2.12</surefire.version>
 		<war.name>${project.build.finalName}</war.name>
+		<project.stage>Production</project.stage>
 	</properties>
 
 	<build>
@@ -474,4 +475,16 @@
 		</plugins>
 	</reporting>
 
+	<repositories>
+		<repository>
+			<id>liferay-public-releases</id>
+			<name>Liferay Public Releases</name>
+			<url>https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/</url>
+		</repository>
+		<repository>
+			<id>liferay-third-party</id>
+			<name>Liferay Third Party</name>
+			<url>https://repository.liferay.com/nexus/content/repositories/third-party/</url>
+		</repository>
+	</repositories>
 </project>

--- a/showcase-common/src/main/java/com/liferay/faces/showcase/application/internal/ResourceVerifierShowcaseImpl.java
+++ b/showcase-common/src/main/java/com/liferay/faces/showcase/application/internal/ResourceVerifierShowcaseImpl.java
@@ -46,7 +46,7 @@ public class ResourceVerifierShowcaseImpl extends ResourceVerifierWrapper implem
 	private static final String BOOTSTRAP_RESOURCE_ID = ResourceUtil.getResourceId("bootstrap",
 			"css/bootstrap.min.css");
 	private static final boolean JQUERY_SATISFIED = (LIFERAY_PORTAL.isDetected() &&
-			(LIFERAY_PORTAL.getMajorVersion() >= 7));
+			(LIFERAY_PORTAL.getMajorVersion() >= 7) && (LIFERAY_PORTAL.getMinorVersion() < 3));
 	private static final String JQUERY_JS_RESOURCE_ID = ResourceUtil.getResourceId("bootstrap", "js/jquery.min.js");
 
 	// Private Members


### PR DESCRIPTION
- Required dependencies are only present in the Liferay repositories, so add them to the pom.xml
- Add missing property `project.stage` defaulting it to Production. The property is used by jsf-showcase-webapp/src/main/webapp/WEB-INF/web.xml
- Enable loading of jquery for liferay >= 7.3 (the jquery module was dropped by then)